### PR TITLE
Fix Docker setup for PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ ADD . /opt/rtb
 
 RUN apt-get update && apt-get install -y \
 build-essential zlib1g-dev rustc \
-python3-pycurl sqlite3 libsqlite3-dev 
+python3-pycurl sqlite3 libsqlite3-dev libpq-dev
 
 ADD ./setup/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt --upgrade
-
-ENV SQL_DIALECT=sqlite
 
 VOLUME ["/opt/rtb/files"]
 ENTRYPOINT ["python3", "/opt/rtb/rootthebox.py", "--setup=docker"]

--- a/README.development.md
+++ b/README.development.md
@@ -7,6 +7,13 @@
 `./rootthebox.py --update`
 Edit files/rootthebox.cfg to set locale (i18n) and database. Sqlite to develop
 sql_dialect = "sqlite"
+# Example configuration for PostgreSQL
+# sql_dialect = "postgres"
+# sql_host = "localhost"
+# sql_port = 5432
+# sql_user = "rtb"
+# sql_password = "rtb"
+# sql_database = "rootthebox"
 -Create database schema
 `./rootthebox.py --setup=prod`
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ If you’re using RootTheBox, please ★Star this repository to show your intere
 
 See the [Root the Box Wiki](https://github.com/moloch--/RootTheBox/wiki)
 
+### PostgreSQL Support
+
+Root the Box can run using a PostgreSQL database. Install the optional
+`psycopg2-binary` dependency and set the SQL dialect to `postgres` in your
+configuration file or via environment variables. A sample docker-compose
+configuration using PostgreSQL is provided.
+
 ## Platform Requirements
 
 -   [Python 3](https://www.python.org/), [PyPy](http://pypy.org/) or [Docker](https://github.com/moloch--/RootTheBox/wiki/Docker-Deployment).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,36 @@
 version: "3"
 services:
+  db:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_DB: rootthebox
+      POSTGRES_USER: rtb
+      POSTGRES_PASSWORD: rtb
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
   memcached:
     image: memcached:latest
     ports:
       - "11211:11211"
   webapp:
     build: .
+    depends_on:
+      - db
+      - memcached
     ports:
       - "8888:8888"
     volumes:
       - ./files:/opt/rtb/files:rw
     environment:
       - COMPOSE_CONVERT_WINDOWS_PATHS=1
+      - SQL_DIALECT=postgres
+      - SQL_HOST=db
+      - SQL_PORT=5432
+      - SQL_DATABASE=rootthebox
+      - SQL_USER=rtb
+      - SQL_PASSWORD=rtb
+volumes:
+  postgres-data:

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -37,11 +37,35 @@ from libs.ConfigHelpers import save_config, save_config_image
 from libs.ConsoleColors import *
 from libs.StringCoding import set_type
 from setup import __version__
+from libs.DatabaseConnection import DatabaseConnection
+from sqlalchemy import create_engine, inspect
 
 
 def current_time():
     """Nicely formatted current time as a string"""
     return str(datetime.now()).split(" ")[1].split(".")[0]
+
+
+def is_db_initialized():
+    """Check if the configured database already contains the schema."""
+    db_connection = DatabaseConnection(
+        database=options.sql_database,
+        hostname=options.sql_host,
+        port=options.sql_port,
+        username=options.sql_user,
+        password=options.sql_password,
+        dialect=options.sql_dialect,
+        ssl_ca=options.sql_sslca,
+    )
+    engine = create_engine(str(db_connection))
+    try:
+        inspector = inspect(engine)
+        return inspector.has_table("theme")
+    except Exception as error:
+        logging.error("Database initialization check failed: %s" % error)
+        return False
+    finally:
+        engine.dispose()
 
 
 def start():
@@ -1162,11 +1186,14 @@ if __name__ == "__main__":
             options.sql_dialect == "sqlite"
             and not os.path.isfile(options.sql_database)
             and not os.path.isfile("%s.db" % options.sql_database)
+        ) or (
+            options.sql_dialect != "sqlite" and not is_db_initialized()
         ):
             logging.info("Running Docker Setup")
             if os.path.isfile(options.config):
                 options.parse_config_file(options.config)
-            options.sql_database = "files/rootthebox.db"
+            if options.sql_dialect == "sqlite":
+                options.sql_database = "files/rootthebox.db"
             options.admin_ips = []  # Remove admin ips due to docker 127.0.0.1 mapping
             options.memcached = "memcached"
             options.x_headers = True

--- a/setup/depends.sh
+++ b/setup/depends.sh
@@ -77,6 +77,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     apt-get install sqlite3 libsqlite3-dev $SKIP
   else
     apt-get install default-mysql-server default-libmysqlclient-dev $SKIP
+    apt-get install postgresql postgresql-contrib libpq-dev $SKIP
   fi
 
 elif [[ "${OSTYPE}" == "darwin14" ]]; then
@@ -95,6 +96,7 @@ elif [[ "${OSTYPE}" == "darwin14" ]]; then
 
   echo "Brew install package..."
   brew install python mysql memcached zlib
+  brew install postgresql
 
 fi	
 

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -15,6 +15,7 @@ sqlalchemy==1.*
 alembic
 enum34
 mysqlclient
+psycopg2-binary
 rocketchat_API
 setuptools-rust==0.10.3; python_version<'3.0'
 setuptools-rust; python_version>='3.0'


### PR DESCRIPTION
## Summary
- avoid overriding SQL_DATABASE during docker setup unless using SQLite
- automatically initialize database on first Postgres run

## Testing
- `pip install nose`
- `nosetests -v` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_68528956001c83269a0590b868d38c66